### PR TITLE
ROD-36 CNC - Create 'Who completed the form' page

### DIFF
--- a/apps/cancel-request/fields/index.js
+++ b/apps/cancel-request/fields/index.js
@@ -27,6 +27,7 @@ module.exports = {
   },
   'cnc-who-is-completing': {
     mixin: 'radio-group',
+    isPageHeading: true,
     options: ['applicant', 'legal-rep', 'sponsor', 'guardian'],
     validate: 'required'
   },

--- a/apps/cancel-request/index.js
+++ b/apps/cancel-request/index.js
@@ -15,12 +15,13 @@ module.exports = {
       next: '/cancel-request-who-completed-form'
     },
     '/cancel-request-who-completed-form': {
+      fields: ['cnc-who-is-completing'],
       forks: [
         {
           target: '/cancel-request-who-representing',
           condition: {
             field: 'cnc-who-is-completing',
-            value: 'cnc-legal-rep'
+            value: 'legal-rep'
           },
           continueOnEdit: false
         },
@@ -29,7 +30,7 @@ module.exports = {
           continueOnEdit: true,
           condition: {
             field: 'cnc-who-is-completing',
-            value: 'cnc-sponsor'
+            value: 'sponsor'
           }
         },
         {
@@ -37,7 +38,7 @@ module.exports = {
           continueOnEdit: true,
           condition: {
             field: 'cnc-who-is-completing',
-            value: 'cnc-guardian'
+            value: 'guardian'
           }
         }
       ],

--- a/apps/cancel-request/translations/src/en/fields.json
+++ b/apps/cancel-request/translations/src/en/fields.json
@@ -13,5 +13,25 @@
         "options": {
             "none_selected": "Select a country"
     }
+        },
+    "cnc-who-is-completing": {
+        "legend": "Who completed the original form?",
+        "hint": "This form must be completed by the same person who made the original request or their authorised legal repesentative",
+        "options": {
+            "applicant": {
+              "label": "The main applicant"
+            },
+            "legal-rep": {
+              "label": "A legal representative",
+              "hint": "This includes legal representatives of main applicants, document holders and sponsors"
+            },
+            "sponsor": {
+              "label": "A sponsor",
+              "hint": "Sponsor means that the application is based on the main applicant’s relationship with you"
+            },
+            "guardian": {
+              "label": "A dependant or guardian of a dependant"
+            }
+          }
         }
-}
+    }

--- a/apps/cancel-request/translations/src/en/validation.json
+++ b/apps/cancel-request/translations/src/en/validation.json
@@ -13,5 +13,8 @@
     },
     "cnc-main-applicant-nationality": {
         "required": "Select the main applicant's country of nationality"
+    },
+    "cnc-who-is-completing": {
+        "required": "Select who completed the original form" 
     }
 }

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -212,3 +212,7 @@ pre.looped-records {
 .govuk-grid-column-one-third.related-services-menu {
   margin-top: 80px;
 }
+.govuk-radios__item .govuk-hint {
+  margin-top: 0rem;
+  padding-left: 0px;
+}


### PR DESCRIPTION
## What? 
[ROD-36](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-36) - Create 'Who completed the form' page - Cancel Request

## Why? 
Allow the user tell us who completed the form.

## How? 
- Added radio buttons with hints
- Added validations

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging

