### PR TITLE
TLF-280: adding error handling of Drone CI variables

### DIFF
--- a/bin/sanity_check_build.sh
+++ b/bin/sanity_check_build.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 set -e
 
-export STATUS=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Status}})
-export BRANCH=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Target}})
-export EVENT=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Event}})
-export REFS=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Ref}})
+get_build_info() {
+  drone build info $GIT_REPO $DRONE_BUILD_PARENT --format $1 || { echo "Failed to fetch build info"; exit 1; }
+}
+
+export STATUS=$(get_build_info {{.Status}})
+export BRANCH=$(get_build_info {{.Target}})
+export EVENT=$(get_build_info {{.Event}})
+export REFS=$(get_build_info {{.Ref}})
 
 if [[ "$STATUS" != "success" ]]; then
   echo "Build number $DRONE_BUILD_PARENT failed due to unsuccessful status."


### PR DESCRIPTION
## What? 
In the script sanity check build, adding error handling to retrieve the drone build parent 
## Why? 
In the Drone CI is failing the sanity check with missing status info.

![Screenshot 2024-10-07 at 10 51 57](https://github.com/user-attachments/assets/0bbb7737-d6f1-4e39-9b20-e62bb910c595)
## How? 
Adding the error handling in the script
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list



- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
