### PR TITLE
ROD- 75 and 76 - ROD -  Added legally representing and sponsor type pages

### DIFF
--- a/apps/rod/fields/index.js
+++ b/apps/rod/fields/index.js
@@ -6,11 +6,21 @@ module.exports = {
   },
   'who-is-completing': {
     mixin: 'radio-group',
+    isPageHeading: true,
     options: ['applicant', 'who-is-rep', 'sponsor', 'guardian'],
-    validate: 'required',
-    legend: {
-      className: 'bold'
-    }
+    validate: 'required'
+  },
+  'who-is-representing': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    options: ['main-applicant', 'document-holder'],
+    validate: 'required'
+  },
+  'sponsor-type': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    options: ['british-sponsor', 'settled-sponsor', 'eea-sponsor'],
+    validate: 'required'
   },
   'is-cancel-application': {
     mixin: 'radio-group',

--- a/apps/rod/index.js
+++ b/apps/rod/index.js
@@ -48,7 +48,7 @@ module.exports = {
       next: '/application'
     },
     '/who-representing': {
-
+      fields: ['who-is-representing'],
       next: '/legal-representation'
     },
     '/legal-representation': {
@@ -56,6 +56,7 @@ module.exports = {
       next: '/application'
     },
     '/sponsor-type': {
+      fields: ['sponsor-type'],
       next: '/application'
     },
     '/dependant-or-guardian': {

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -6,6 +6,14 @@ module.exports = {
       {
         step: '/who-completing',
         field: 'who-is-completing'
+      },
+      {
+        step: '/who-representing',
+        field: 'who-is-representing'
+      },
+      {
+        step: '/sponsor-type',
+        field: 'sponsor-type'
       }
     ]
   }

--- a/apps/rod/translations/src/en/fields.json
+++ b/apps/rod/translations/src/en/fields.json
@@ -6,16 +6,48 @@
         "legend": "Who is completing this form?",
         "options":{
             "applicant": {
-                "label": "Main applicant"
+                "label": "The main applicant"
             },
             "who-is-rep": {
-                "label": "Skeleton"
+                "label": "A legal representative",
+                "hint": "This includes legal representatives of main applicants, document holders and sponsors"
             },
-            "sponsor":{
-                "label": "Skeleton"
+            "sponsor": {
+                "label": "A sponsor",
+                "hint": "Sponsor means that the application is based on the main applicant’s relationship with you"
             },
             "guardian" :{
-                "label": "Skeleton"
+                "label": "A dependant or guardian of a dependant"
+            }
+        }
+    },
+    "who-is-representing": {
+        "legend": "Who are you legally representing?",
+        "hint": "You must have sent a signed letter of authority to the Home Office to act on this person’s behalf",
+        "options":{
+            "main-applicant": {
+                "label": "The main applicant"
+            },
+            "document-holder": {
+                "label": "A document holder"
+            }
+        }
+    },
+    "sponsor-type": {
+        "legend": "What type of sponsor are you?",
+        "hint": "Sponsor means that the application is based on the main applicant’s relationship with you",
+        "options":{
+            "british-sponsor": {
+                "label": "A British sponsor",
+                "hint": "You have British citizenship"
+            },
+            "settled-sponsor": {
+                "label": "A settled sponsor",
+                "hint": "You have settlement (also called indefinite leave to remain)"
+            },
+            "eea-sponsor": {
+                "label": "An EEA citizen sponsor",
+                "hint": "You are a citizen of an EU country, Switzerland, Norway, Iceland or Lichtenstein"
             }
         }
     },

--- a/apps/rod/translations/src/en/pages.json
+++ b/apps/rod/translations/src/en/pages.json
@@ -12,6 +12,12 @@
     "fields": {
       "who-is-completing": {
         "label": "Person completing form"
+      },
+      "who-is-representing": {
+        "label": "Legally representing"
+      },
+      "sponsor-type": {
+        "label": "Sponsor type"
       }
     }
   }

--- a/apps/rod/translations/src/en/validation.json
+++ b/apps/rod/translations/src/en/validation.json
@@ -1,1 +1,11 @@
-{}
+{
+    "who-is-completing": {
+        "required": "Select who is completing this form"
+    },
+    "who-is-representing": {
+        "required": "Select who you are legally representing"
+    },
+    "sponsor-type": {
+        "required": "Select what type of sponsor you are"
+    }
+}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -221,4 +221,5 @@ pre.looped-records {
 .govuk-radios__item .govuk-hint {
   margin-top: 0rem;
   padding-left: 0px;
+  margin-bottom: 0px;
 }


### PR DESCRIPTION
## What? 
[ROD-75](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-75) - Create LEGALLY REPRESENTING screen
[ROD-76](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-76) - Create SPONSOR screen

## Why? 
- Added new pages for LEGALLY REPRESENTING and SPONSOR page in ROD main flow
- Added required field validation for all pages

## How? 
- Added necessary step configuration and field specific variables.

## Testing?
## Screenshots (optional)

## Anything Else? (optional)
- Added fix for the backlink on the first page after the start pages in all three flow - [ROD-95](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-95)
- Added serviceName in journey.json for all three flows and added the layout.html to render <title>
- Added template for confirmation screen for all three flows and added required css

## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
