### PR TITLE
ROD-39-add further leave to remain page to DNR journey

### DIFF
--- a/apps/report-documents-not-received/fields/index.js
+++ b/apps/report-documents-not-received/fields/index.js
@@ -43,5 +43,13 @@ module.exports = {
       label: 'fields.dnr-nationality.options.none_selected'
     }].concat(countries),
     validate: 'required'
+  },
+  'dnr-further-leave-to-remain': {
+    mixin: 'radio-group',
+    options: ['flr-fp', 'flr-m', 'flr-ir', 'flr-hro'],
+    validate: 'required',
+    legend: {
+      className: 'govuk-label--m'
+    }
   }
 };

--- a/apps/report-documents-not-received/index.js
+++ b/apps/report-documents-not-received/index.js
@@ -79,6 +79,7 @@ module.exports = {
       next: '/documents-not-received-reference-number'
     },
     '/documents-not-received-further-leave': {
+      fields: ['dnr-further-leave-to-remain'],
       next: '/documents-not-received-reference-number'
     },
     '/documents-not-received-reference-number': {

--- a/apps/report-documents-not-received/translations/src/en/fields.json
+++ b/apps/report-documents-not-received/translations/src/en/fields.json
@@ -39,5 +39,22 @@
         "none_selected": "Select a country"
       },
       "hint": "This must match what is on the main applicant’s immigration document"
+    },
+    "dnr-further-leave-to-remain": {
+        "legend": "Which type of further leave did you apply for?",
+        "options": {
+          "flr-fp": {
+            "label": "FLR (FP)"
+          },
+          "flr-m": {
+            "label": "FLR (M)"
+          },
+          "flr-ir": {
+            "label": "FLR (IR)"
+          },
+          "flr-hro": {
+            "label": "FLR (HRO)"
+          }
+        }
     }
 }

--- a/apps/report-documents-not-received/translations/src/en/pages.json
+++ b/apps/report-documents-not-received/translations/src/en/pages.json
@@ -12,5 +12,12 @@
   },
   "documents-not-received-main-applicant": {
     "header": "Main applicant’s details"
+  },
+  "documents-not-received-further-leave": {
+    "header": "Further leave to remain (permission to stay)",
+    "p1": "There are different categories of further leave to remain (also called permission to stay), depending on your circumstances.",
+    "link-read-more": "Read more about the types of further leave",
+    "p2": "to check which one you applied for.",
+    "p3": "You will have used an online form called 'FLR' to apply. You will have applied from inside the UK."
   }
 }

--- a/apps/report-documents-not-received/translations/src/en/validation.json
+++ b/apps/report-documents-not-received/translations/src/en/validation.json
@@ -13,5 +13,8 @@
   },
   "dnr-nationality": {
     "required": "Select the main applicant's country of nationality"
+  },
+  "dnr-further-leave-to-remain": {
+    "required": "Select which type of further leave you applied for"
   }
 }

--- a/apps/report-documents-not-received/views/documents-not-received-further-leave.html
+++ b/apps/report-documents-not-received/views/documents-not-received-further-leave.html
@@ -1,0 +1,15 @@
+{{<partials-page}}
+  {{$page-content}}
+  <p class="govuk-body">
+    {{#t}}pages.documents-not-received-further-leave.p1{{/t}}
+  </p>
+  <p class="govuk-body">
+    <a href="https://visas-immigration.service.gov.uk/product/family-routes">{{#t}}pages.documents-not-received-further-leave.link-read-more{{/t}}</a> {{#t}}pages.documents-not-received-further-leave.p2{{/t}}
+  </p>
+  <p class="govuk-body">
+    {{#t}}pages.documents-not-received-further-leave.p3{{/t}}
+  </p>
+  {{#renderField}}dnr-further-leave-to-remain{{/renderField}}
+  {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 
Relates [ROD-39](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-39)
Add further leave to remain page to DNR journey
## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
