### PR TITLE
ROD-77 and ROD- 78 - Added new pages /dependant-or-guardian and /legal-representation

### DIFF
--- a/apps/rod/fields/index.js
+++ b/apps/rod/fields/index.js
@@ -22,6 +22,19 @@ module.exports = {
     options: ['british-sponsor', 'settled-sponsor', 'eea-sponsor'],
     validate: 'required'
   },
+  'dependant-or-guardian': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    options: ['dependant-over-18', 'parent-guardian-under-18'],
+    validate: 'required'
+  },
+  'confirm-sent-letter-of-authority': {
+    mixin: 'checkbox',
+    validate: ['required']
+  },
+  'legal-rep-name': {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 150 }]
+  },
   'is-cancel-application': {
     mixin: 'radio-group',
     isPageHeading: true,

--- a/apps/rod/index.js
+++ b/apps/rod/index.js
@@ -52,7 +52,7 @@ module.exports = {
       next: '/legal-representation'
     },
     '/legal-representation': {
-
+      fields: ['confirm-sent-letter-of-authority', 'legal-rep-name'],
       next: '/application'
     },
     '/sponsor-type': {
@@ -60,6 +60,7 @@ module.exports = {
       next: '/application'
     },
     '/dependant-or-guardian': {
+      fields: ['dependant-or-guardian'],
       next: '/application'
     },
     '/application': {

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -15,6 +15,14 @@ module.exports = {
       field: 'sponsor-type'
     },
     {
+      step: '/dependant-or-guardian',
+      field: 'dependant-or-guardian'
+    },
+    {
+      step: '/legal-representation',
+      field: 'legal-rep-name'
+    },
+    {
       step: '/application',
       field: 'application-type'
     },

--- a/apps/rod/translations/src/en/fields.json
+++ b/apps/rod/translations/src/en/fields.json
@@ -51,6 +51,25 @@
             }
         }
     },
+    "dependant-or-guardian": {
+        "legend": "Are you a dependant or a guardian of a dependant?",
+        "options":{
+            "dependant-over-18": {
+                "label": "A dependant aged 18 or over",
+                "hint": "You are an adult named as a dependant on the application"
+            },
+            "parent-guardian-under-18": {
+                "label": "A parent or guardian of a dependant who is under 18",
+                "hint": "You are acting on behalf of a child named as a dependant on the application"
+            }
+        }
+    },
+    "confirm-sent-letter-of-authority": {
+        "label": "I confirm I have sent the Home Office a signed letter of authority"
+    },
+    "legal-rep-name": {
+        "label": "Name of legal firm or representative"
+    },
     "is-cancel-application": {
         "label": "Any documents that were sent with the application will be returned",
         "options":{

--- a/apps/rod/translations/src/en/pages.json
+++ b/apps/rod/translations/src/en/pages.json
@@ -2,6 +2,12 @@
   "start": {
     "header": "Cancel an application and get your documents back"
   },
+  "legal-representation": {
+    "header": "Legal representation",
+    "p1": "To continue this form, you must have previously",
+    "link": "sent the Home Office a letter of authority",
+    "p2": "signed by your client."
+  },
   "sectionHeader": {
     "header": "Check your answers"
   },
@@ -18,6 +24,12 @@
       },
       "sponsor-type": {
         "label": "Sponsor type"
+      },
+      "dependant-or-guardian": {
+        "label": "Sponsor type"
+      },
+      "legal-rep-name": {
+        "label": "Legal firm or representative name"
       },
       "is-cancel-application": {
         "label": "Cancelling application?"

--- a/apps/rod/translations/src/en/validation.json
+++ b/apps/rod/translations/src/en/validation.json
@@ -7,5 +7,16 @@
     },
     "sponsor-type": {
         "required": "Select what type of sponsor you are"
+    },
+    "dependant-or-guardian": {
+        "required": "Select whether you are a dependant or a guardian of a dependant"
+    },
+    "confirm-sent-letter-of-authority": {
+        "required": "Confirm you have sent the Home Office a letter of authority"
+    },
+    "legal-rep-name": {
+        "required": "Enter the name of the legal firm or representative",
+        "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer.",
+        "maxlength": "Name or legal firm or representative must be less than 150 characters"
     }
 }

--- a/apps/rod/views/legal-representation.html
+++ b/apps/rod/views/legal-representation.html
@@ -1,0 +1,12 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p class="govuk-body">
+      {{#t}}pages.legal-representation.p1{{/t}}
+      <a href="https://www.update-my-details.homeoffice.gov.uk/overview" class="govuk-link">{{#t}}pages.legal-representation.link{{/t}}</a>
+      {{#t}}pages.legal-representation.p2{{/t}}
+    </p>
+    {{#renderField}}confirm-sent-letter-of-authority{{/renderField}}
+    {{#input-text}}legal-rep-name{{/input-text}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 
- [ROD-77](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-77) - Create DEPENDANT or GUARDIAN screen
- [ROD-78](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-78) - Create a LEGAL REPRESENTATION screen

## Why? 
- Creating new pages for DEPENDANT or GUARDIAN and LEGAL REPRESENTATION page in ROD main flow

## How? 
- Added necessary step configuration and field specific variables.
- Added required field validation for all pages
- Added summary page entry in summary-data-sections.js

## Testing?
## Screenshots (optional)

## Anything Else? (optional)

## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
