### PR TITLE
ROD-110 Different type of visa option removed

### DIFF
--- a/apps/cancel-request/fields/index.js
+++ b/apps/cancel-request/fields/index.js
@@ -204,8 +204,7 @@ module.exports = {
       'skilled-worker',
       'study',
       'temporary-worker',
-      'turkish-national',
-      'different-type'
+      'turkish-national'
     ],
     validate: 'required'
   },

--- a/apps/cancel-request/translations/src/en/fields.json
+++ b/apps/cancel-request/translations/src/en/fields.json
@@ -72,9 +72,6 @@
       "turkish-national": {
         "label": "Turkish national visa",
         "hint": "Includes Turkish businessperson and Turkish worker visas"
-      },
-      "different-type": {
-        "label": "A different type of visa"
       }
     }
   },

--- a/apps/report-documents-not-received/fields/index.js
+++ b/apps/report-documents-not-received/fields/index.js
@@ -59,8 +59,7 @@ module.exports = {
       'dnr-visa-type-skilled',
       'dnr-visa-type-study',
       'dnr-visa-type-temp',
-      'dnr-visa-type-turkish',
-      'dnr-visa-type-different'
+      'dnr-visa-type-turkish'
     ],
     validate: 'required'
   },

--- a/apps/report-documents-not-received/translations/src/en/fields.json
+++ b/apps/report-documents-not-received/translations/src/en/fields.json
@@ -69,9 +69,6 @@
       "dnr-visa-type-turkish" :{
         "label": "Turkish national visa",
         "hint": "Includes Turkish businessperson and Turkish worker visas"
-      },
-      "dnr-visa-type-different" :{
-        "label": "A different type of visa"
       }
     }
   },

--- a/apps/rod/fields/index.js
+++ b/apps/rod/fields/index.js
@@ -116,8 +116,7 @@ module.exports = {
       'visa-type-skilled',
       'visa-type-study',
       'visa-type-temp',
-      'visa-type-turkish',
-      'visa-type-different'
+      'visa-type-turkish'
     ],
     validate: 'required'
   },

--- a/apps/rod/translations/src/en/fields.json
+++ b/apps/rod/translations/src/en/fields.json
@@ -147,9 +147,6 @@
           "visa-type-turkish": {
             "label": "Turkish national visa",
             "hint": "Includes Turkish businessperson and Turkish worker visas"
-          },
-          "visa-type-different": {
-            "label": "A different type of visa"
           }
         }
     },


### PR DESCRIPTION
## What? 
[ROD-110](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-110) - A different type of visa option removal
## Why? 
## How? 
A different type of visa option is removed from all 3 flows
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
