### PR TITLE
ROD-105 Create a delivery address for documents page

### DIFF
--- a/apps/rod/fields/index.js
+++ b/apps/rod/fields/index.js
@@ -60,7 +60,11 @@ module.exports = {
     mixin: 'radio-group',
     isPageHeading: true,
     options: ['yes', 'no'],
-    validate: 'required'
+    validate: 'required',
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-fieldset__legend govuk-fieldset__legend--s'
+    }
   },
   'is-requesting-passport-to-travel': {
     mixin: 'radio-group',

--- a/apps/rod/translations/src/en/fields.json
+++ b/apps/rod/translations/src/en/fields.json
@@ -67,11 +67,12 @@
     "confirm-sent-letter-of-authority": {
         "label": "I confirm I have sent the Home Office a signed letter of authority"
     },
+    
     "legal-rep-name": {
         "label": "Name of legal firm or representative"
     },
     "is-passport-return-address": {
-        "label": "Should the documents be returned to this address",
+        "legend": "Should the documents be returned to this address",
         "options": {
             "yes": {
                 "label": "Yes"

--- a/apps/rod/translations/src/en/pages.json
+++ b/apps/rod/translations/src/en/pages.json
@@ -51,7 +51,9 @@
   "enter-main-applicant-address": {
     "header": "Enter the main applicant’s address",
     "intro": "This must match the applicant’s address in Home Office records. The address must be a UK address."
-    
+  },
+  "reuse-main-applicant-address": {
+    "header": "Delivery address for the documents"
   },
   "confirm": {
     "fields": {

--- a/apps/rod/translations/src/en/validation.json
+++ b/apps/rod/translations/src/en/validation.json
@@ -122,5 +122,8 @@
     "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
     "postCode": "Postcode must only include letters a-z, numbers and spaces",
     "postcode": "Enter a real UK postcode"
+  },
+  "is-passport-return-address": {
+    "required": "Select whether to return documents to the main applicant's address"
   }
 }

--- a/apps/rod/views/content/delivery-address-for-documents.md
+++ b/apps/rod/views/content/delivery-address-for-documents.md
@@ -1,0 +1,3 @@
+The Home Office only return documents to addresses they have in their records. If the main applicant or their legal representative has moved since the application was made, they must <a href="https://www.update-my-details.homeoffice.gov.uk/overview" target="_blank">tell UK Visas and Immigration about the change of address.</a>
+
+You told us the main applicant’s address is:

--- a/apps/rod/views/reuse-main-applicant-address.html
+++ b/apps/rod/views/reuse-main-applicant-address.html
@@ -1,0 +1,21 @@
+{{<partials-page}}
+  {{$page-content}}
+  {{#markdown}}delivery-address-for-documents{{/markdown}} 
+
+  <div class="govuk-details__text">
+  <div class="govuk-summary-list__row summary-list-box" >
+        <div>{{values.main-applicant-address-1}}</div>
+        <div>{{values.main-applicant-address-2}}</div>
+        <div>{{values.main-applicant-town-or-city}}</div>
+        <div>{{values.main-applicant-postcode}}</div>
+    </div>
+  </div>
+  <br>
+    {{#fields}}
+    {{#renderField}}{{/renderField}}
+    {{/fields}}
+  <div class="govuk-button-container">
+    {{#input-submit}}continue{{/input-submit}}
+  </div>
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 
[ROD-105](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-105) - ROD-105 Create a delivery address for documents page - ROD main flow

## Why? 
Allows user to select if they are a dependant or a guardian of a dependant

## How? 
- Added Heading and radio buttons for page 
- Added text with hyperlink
- Added validations for page

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging