### PR TITLE
ROD-138 Add logic to hide information if user selects they are a sponsor

### DIFF
--- a/apps/rod/behaviours/send-email-notification.js
+++ b/apps/rod/behaviours/send-email-notification.js
@@ -58,6 +58,15 @@ const getApplicationCategory = req => {
   return getLabelForField(req, 'application-type');
 };
 
+const hasCancelApplication = req => {
+  if (req.sessionModel.get('isSponsor')) {
+    return 'no';
+  }
+
+  const cancelApplication = req.sessionModel.get('cancel-application');
+  return cancelApplication ? 'yes' : 'no';
+};
+
 const getUserDetails = req => {
   return {
     record_number: req.sessionModel.get('uniqueRodReference'),
@@ -66,12 +75,13 @@ const getUserDetails = req => {
     application_submitted_date: dateFormatter.format(
       new Date(getValueOfDefault(req, 'date-of-application'))
     ),
-    has_cancel_application: getYesOrNoStr(req, 'cancel-application'),
-    cancel_application: getLabelForField(req, 'cancel-application'),
-    has_applicant_passport: getYesOrNoStr(
-      req,
-      'is-requesting-passport-to-travel'
-    ),
+    has_cancel_application: hasCancelApplication(req),
+    cancel_application: getLabelForField(req, 'cancel-application') || 'No',
+    has_applicant_passport:
+      !req.sessionModel.get('isSponsor') &&
+      req.sessionModel.get('is-requesting-passport-to-travel')
+        ? 'yes'
+        : 'no',
     applicant_passport: getLabelForField(
       req,
       'is-requesting-passport-to-travel'

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const config = require('../../../config');
-const dateFormater = new Intl.DateTimeFormat(
+const dateFormatter = new Intl.DateTimeFormat(
   config.dateLocales,
   config.dateFormat
 );
@@ -43,22 +43,22 @@ module.exports = {
     {
       step: '/about-application',
       field: 'date-of-application',
-      parse: (d, req) => {
-        const isSponsor = req.sessionModel.get('who-is-completing') === 'sponsor';
-        return !isSponsor && d ? dateFormater.format(new Date(d)) : null;
-      }
+      parse: d => d && dateFormatter.format(new Date(d))
     },
     {
       step: '/about-application',
       field: 'cancel-application',
       parse: (value, req) => {
-        const isSponsor = req.sessionModel.get('who-is-completing') === 'sponsor';
-        return !isSponsor ? value : null;
+        if (req.sessionModel.get('isSponsor')) {
+          return null;
+        }
+        return value ? value : 'No';
       }
     },
     {
       step: '/main-applicant-passport',
-      field: 'is-requesting-passport-to-travel'
+      field: 'is-requesting-passport-to-travel',
+      parse: (value, req) => req.sessionModel.get('isSponsor') ? null : value
     },
     {
       step: '/reference-number',
@@ -110,7 +110,7 @@ module.exports = {
     {
       step: '/main-applicant',
       field: 'main-applicant-dob',
-      parse: d => d && dateFormater.format(new Date(d))
+      parse: d => d && dateFormatter.format(new Date(d))
     },
     {
       step: '/main-applicant',

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -35,11 +35,18 @@ module.exports = {
     {
       step: '/about-application',
       field: 'date-of-application',
-      parse: d => d && dateFormater.format(new Date(d))
+      parse: (d, req) => {
+        const isSponsor = req.sessionModel.get('who-is-completing') === 'sponsor';
+        return !isSponsor && d ? dateFormater.format(new Date(d)) : null;
+      }
     },
     {
       step: '/about-application',
-      field: 'cancel-application'
+      field: 'cancel-application',
+      parse: (value, req) => {
+        const isSponsor = req.sessionModel.get('who-is-completing') === 'sponsor';
+        return !isSponsor ? value : null;
+      }
     },
     {
       step: '/dependant-or-guardian',


### PR DESCRIPTION
## What? 
[ROD-138](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-138) - Date of submission and Cancelling application? should not appear if the person completing the form is a sponsor.

## Why? 


## How? 
- Added logic


## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging