### PR TITLE
ROD-151 Add UAN field

### DIFF
--- a/apps/cancel-request/behaviours/send-email-notification.js
+++ b/apps/cancel-request/behaviours/send-email-notification.js
@@ -95,6 +95,14 @@ const getUserDetails = req => {
       req,
       'enter-courier-reference-number'
     ),
+    has_unique_application_number: getYesOrNoStr(
+      req,
+      'enter-unique-application-number'
+    ),
+    unique_application_number: getValueOfDefault(
+      req,
+      'enter-unique-application-number'
+    ),
     contact_email: getValueOfDefault(req, 'cnc-email'),
     contact_telephone: getValueOfDefault(req, 'cnc-telephone')
   };

--- a/apps/cancel-request/fields/index.js
+++ b/apps/cancel-request/fields/index.js
@@ -202,11 +202,11 @@ module.exports = {
     className: ['govuk-input'],
     validate: [
       'required',
+      'notUrl',
       { type: 'minlength', arguments: 16 },
       { type: 'maxlength', arguments: 22 },
       { type: 'regex', arguments: /^(([\d\-\/]+)?)$/ },
-      isValidUANRef,
-      'notUrl'
+      isValidUANRef
     ]
   },
   'cnc-application-visa-type': {

--- a/apps/cancel-request/fields/index.js
+++ b/apps/cancel-request/fields/index.js
@@ -4,7 +4,8 @@ const countries = require('hof').utils.countries();
 const validators = require('hof/controller/validation/validators');
 const {
   removeWhiteSpace,
-  validInternationalPhoneNumber
+  validInternationalPhoneNumber,
+  isValidUANRef
 } = require('../../../utils');
 
 function recordMaxLength(value) {
@@ -124,6 +125,11 @@ module.exports = {
         value: 'courier-reference-number',
         toggle: 'enter-courier-reference-number',
         child: 'input-text'
+      },
+      {
+        value: 'unique-application-number',
+        toggle: 'enter-unique-application-number',
+        child: 'input-text'
       }
     ]
   },
@@ -187,6 +193,21 @@ module.exports = {
     },
     className: ['govuk-input'],
     validate: ['required', { type: 'maxlength', arguments: 100 }, 'notUrl']
+  },
+  'enter-unique-application-number': {
+    dependent: {
+      field: 'cnc-reference-number',
+      value: 'unique-application-number'
+    },
+    className: ['govuk-input'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 16 },
+      { type: 'maxlength', arguments: 22 },
+      { type: 'regex', arguments: /^(([\d\-\/]+)?)$/ },
+      isValidUANRef,
+      'notUrl'
+    ]
   },
   'cnc-application-visa-type': {
     mixin: 'radio-group',

--- a/apps/cancel-request/index.js
+++ b/apps/cancel-request/index.js
@@ -94,7 +94,8 @@ module.exports = {
         'enter-case-id',
         'enter-ho-reference-number',
         'enter-payment-reference-number',
-        'enter-courier-reference-number'
+        'enter-courier-reference-number',
+        'enter-unique-application-number'
       ],
       next: '/cancel-request-contact-details'
     },

--- a/apps/cancel-request/sections/summary-data-sections.js
+++ b/apps/cancel-request/sections/summary-data-sections.js
@@ -85,6 +85,10 @@ module.exports = {
       field: 'enter-courier-reference-number'
     },
     {
+      step: '/cancel-request-reference-number',
+      field: 'enter-unique-application-number'
+    },
+    {
       step: '/cancel-request-contact-details',
       field: 'cnc-email'
     },

--- a/apps/cancel-request/translations/src/en/fields.json
+++ b/apps/cancel-request/translations/src/en/fields.json
@@ -145,6 +145,10 @@
       "courier-reference-number": {
         "label": "Courier reference number",
         "hint": "This includes Royal Mail reference numbers"
+      },
+      "unique-application-number": {
+        "label": "Unique Application Number (UAN)",
+        "hint": "This is on letters and emails from the Home Office"
       }
     }
   },
@@ -163,6 +167,10 @@
   "enter-courier-reference-number": {
     "label": "Enter the courier reference number",
     "hint": "Royal Mail reference numbers are between 9 and 27 characters long"
+  },
+  "enter-unique-application-number": {
+    "label": "Enter the UAN",
+    "hint": "For example, 1111-2222-3333-4444"
   },
   "cnc-reason-for-application": {
     "legend": "What is the application for?",

--- a/apps/cancel-request/translations/src/en/pages.json
+++ b/apps/cancel-request/translations/src/en/pages.json
@@ -65,6 +65,9 @@
       "enter-courier-reference-number": {
         "label": "Courier reference number"
       },
+      "enter-unique-application-number": {
+        "label": "Unique application number"
+      },
       "cnc-email": {
         "label": "Contact email"
       },

--- a/apps/cancel-request/translations/src/en/validation.json
+++ b/apps/cancel-request/translations/src/en/validation.json
@@ -72,7 +72,7 @@
     "required": "Enter a unique application number",
     "minlength": "Unique application number must be more than 15 numbers",
     "maxlength": "Unique application number must be less than 23 numbers",
-    "notUrl": "Your answer must not contain URLs or links",
+    "notUrl": "Answer must not contain a URL",
     "regex": "Enter a valid UAN. For example, 1111-2222-3333-4444",
     "isValidUANRef": "Enter a valid UAN. For example, 1111-2222-3333-4444"
   },

--- a/apps/cancel-request/translations/src/en/validation.json
+++ b/apps/cancel-request/translations/src/en/validation.json
@@ -68,6 +68,14 @@
     "maxlength": "Courier reference number cannot be more than 100 characters",
     "notUrl": "Answer must not contain a URL"
   },
+  "enter-unique-application-number": {
+    "required": "Enter a unique application number",
+    "minlength": "Unique application number must be more than 15 numbers",
+    "maxlength": "Unique application number must be less than 23 numbers",
+    "notUrl": "Your answer must not contain URLs or links",
+    "regex": "Enter a valid UAN. For example, 1111-2222-3333-4444",
+    "isValidUANRef": "Enter a valid UAN. For example, 1111-2222-3333-4444"
+  },
   "cnc-reason-for-application": {
     "required": "Select what the application was for"
   },

--- a/apps/report-documents-not-received/behaviours/send-email-notification.js
+++ b/apps/report-documents-not-received/behaviours/send-email-notification.js
@@ -71,6 +71,14 @@ const getUserDetails = req => {
       req,
       'dnr-courier-reference-number'
     ),
+    has_unique_application_number: getYesOrNoStr(
+      req,
+      'dnr-unique-application-number'
+    ),
+    unique_application_number: getValueOfDefault(
+      req,
+      'dnr-unique-application-number'
+    ),
     contact_email: getValueOfDefault(req, 'dnr-email'),
     contact_telephone: getValueOfDefault(req, 'dnr-telephone')
   };

--- a/apps/report-documents-not-received/fields/index.js
+++ b/apps/report-documents-not-received/fields/index.js
@@ -164,11 +164,11 @@ module.exports = {
     className: ['govuk-input'],
     validate: [
       'required',
+      'notUrl',
       { type: 'minlength', arguments: 16 },
       { type: 'maxlength', arguments: 22 },
       { type: 'regex', arguments: /^(([\d\-\/]+)?)$/ },
-      isValidUANRef,
-      'notUrl'
+      isValidUANRef
     ]
   },
   'dnr-email': {

--- a/apps/report-documents-not-received/fields/index.js
+++ b/apps/report-documents-not-received/fields/index.js
@@ -2,7 +2,10 @@
 
 const countries = require('hof').utils.countries();
 const dateComponent = require('hof').components.date;
-const { validInternationalPhoneNumber } = require('../../../utils');
+const {
+  validInternationalPhoneNumber,
+  isValidUANRef
+} = require('../../../utils');
 
 module.exports = {
   'dnr-application-type': {
@@ -98,6 +101,11 @@ module.exports = {
         value: 'dnr-courier-reference-number',
         toggle: 'dnr-courier-reference-number',
         child: 'input-text'
+      },
+      {
+        value: 'dnr-unique-application-number',
+        toggle: 'dnr-unique-application-number',
+        child: 'input-text'
       }
     ]
   },
@@ -147,6 +155,21 @@ module.exports = {
     },
     className: ['govuk-input'],
     validate: ['required', { type: 'maxlength', arguments: 100 }, 'notUrl']
+  },
+  'dnr-unique-application-number': {
+    dependent: {
+      field: 'dnr-reference-number',
+      value: 'dnr-unique-application-number'
+    },
+    className: ['govuk-input'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 16 },
+      { type: 'maxlength', arguments: 22 },
+      { type: 'regex', arguments: /^(([\d\-\/]+)?)$/ },
+      isValidUANRef,
+      'notUrl'
+    ]
   },
   'dnr-email': {
     mixin: 'input-text',

--- a/apps/report-documents-not-received/index.js
+++ b/apps/report-documents-not-received/index.js
@@ -50,7 +50,8 @@ module.exports = {
         'dnr-case-id',
         'dnr-ho-reference-number',
         'dnr-payment-reference-number',
-        'dnr-courier-reference-number'
+        'dnr-courier-reference-number',
+        'dnr-unique-application-number'
       ],
       next: '/documents-not-received-contact-details'
     },

--- a/apps/report-documents-not-received/sections/summary-data-sections.js
+++ b/apps/report-documents-not-received/sections/summary-data-sections.js
@@ -65,6 +65,10 @@ module.exports = {
       field: 'dnr-courier-reference-number'
     },
     {
+      step: '/documents-not-received-reference-number',
+      field: 'dnr-unique-application-number'
+    },
+    {
       step: '/documents-not-received-contact-details',
       field: 'dnr-email'
     },

--- a/apps/report-documents-not-received/translations/src/en/fields.json
+++ b/apps/report-documents-not-received/translations/src/en/fields.json
@@ -1,34 +1,34 @@
 {
   "dnr-application-type": {
     "legend": "What is the application for?",
-    "options":{
-      "dnr-visa":{
-          "label": "A visa",
-          "hint": "Includes British National (Overseas) visas"
-        },
-        "dnr-british-citizen":{
-          "label": "British citizenship",
-          "hint": "Includes status letters, right of abode, confirmation of non-acquisition, the Windrush Scheme and applications to give up citizenship"
-        },
-        "dnr-further-leave":{
-          "label": "Further leave to remain",
-          "hint": "Includes FLR (M), FLR (FP), FLR (O), and FLR (HRO) applications"
-        },
-        "dnr-not-time-limit":{
-          "label": "No time limit or replacement settlement biometric residence permit"
-        },
-        "dnr-eu-settlement-scheme":{
-          "label": "Settled or pre-settled status under the European Union Settlement Scheme"
-        },
-        "dnr-settlement":{
-          "label": "Settlement",
-          "hint": "Also called ‘indefinite leave to remain’ or ‘indefinite permission to stay’"
-        },
-        "dnr-limited-leave-replacement-brp":{
-          "label": "Transfer of conditions or limited leave replacement biometric residence permit"
-        }
+    "options": {
+      "dnr-visa": {
+        "label": "A visa",
+        "hint": "Includes British National (Overseas) visas"
+      },
+      "dnr-british-citizen": {
+        "label": "British citizenship",
+        "hint": "Includes status letters, right of abode, confirmation of non-acquisition, the Windrush Scheme and applications to give up citizenship"
+      },
+      "dnr-further-leave": {
+        "label": "Further leave to remain",
+        "hint": "Includes FLR (M), FLR (FP), FLR (O), and FLR (HRO) applications"
+      },
+      "dnr-not-time-limit": {
+        "label": "No time limit or replacement settlement biometric residence permit"
+      },
+      "dnr-eu-settlement-scheme": {
+        "label": "Settled or pre-settled status under the European Union Settlement Scheme"
+      },
+      "dnr-settlement": {
+        "label": "Settlement",
+        "hint": "Also called ‘indefinite leave to remain’ or ‘indefinite permission to stay’"
+      },
+      "dnr-limited-leave-replacement-brp": {
+        "label": "Transfer of conditions or limited leave replacement biometric residence permit"
       }
-    },
+    }
+  },
   "dnr-full-name": {
     "label": "Full name",
     "hint": "Enter the main applicant’s name exactly as it appears on their immigration document"
@@ -54,19 +54,19 @@
         "label": "Exceptional talent visa",
         "hint": "Also called tier 1 in the points-based system"
       },
-      "dnr-visa-type-skilled":{
+      "dnr-visa-type-skilled": {
         "label": "Skilled worker visa",
         "hint": "Also called tier 2 in the points-based system"
       },
-      "dnr-visa-type-study" :{
+      "dnr-visa-type-study": {
         "label": "Study visa",
         "hint": "Also called tier 4 in the points-based system"
       },
-      "dnr-visa-type-temp":{
+      "dnr-visa-type-temp": {
         "label": "Temporary work visa",
         "hint": "Also called tier 5 in the points-based system"
       },
-      "dnr-visa-type-turkish" :{
+      "dnr-visa-type-turkish": {
         "label": "Turkish national visa",
         "hint": "Includes Turkish businessperson and Turkish worker visas"
       }
@@ -94,6 +94,10 @@
       "dnr-courier-reference-number": {
         "label": "Courier reference number",
         "hint": "This includes Royal Mail reference numbers"
+      },
+      "dnr-unique-application-number": {
+        "label": "Unique Application Number (UAN)",
+        "hint": "This is on letters and emails from the Home Office"
       }
     }
   },
@@ -112,12 +116,16 @@
   "dnr-courier-reference-number": {
     "label": "Enter the courier reference number",
     "hint": "Royal Mail reference numbers are between 9 and 27 characters long"
-  }, 
-  "dnr-email":{
+  },
+  "dnr-unique-application-number": {
+    "label": "Enter the UAN",
+    "hint": "For example, 1111-2222-3333-4444"
+  },
+  "dnr-email": {
     "label": "Email address",
     "hint": "This is where we will send confirmation of your submitted report"
   },
-  "dnr-telephone":{
+  "dnr-telephone": {
     "label": "Contact telephone number",
     "hint": "For international numbers, include the country code"
   },

--- a/apps/report-documents-not-received/translations/src/en/pages.json
+++ b/apps/report-documents-not-received/translations/src/en/pages.json
@@ -13,7 +13,7 @@
   "documents-not-received-main-applicant": {
     "header": "Main applicant’s details"
   },
-  "documents-not-received-contact-details":{
+  "documents-not-received-contact-details": {
     "header": "Contact details"
   },
   "documents-not-received-further-leave": {
@@ -69,6 +69,9 @@
       },
       "dnr-courier-reference-number": {
         "label": "Courier reference number"
+      },
+      "dnr-unique-application-number": {
+        "label": "Unique application number"
       }
     }
   }

--- a/apps/report-documents-not-received/translations/src/en/validation.json
+++ b/apps/report-documents-not-received/translations/src/en/validation.json
@@ -62,7 +62,7 @@
     "required": "Enter a unique application number",
     "minlength": "Unique application number must be more than 15 numbers",
     "maxlength": "Unique application number must be less than 23 numbers",
-    "notUrl": "Your answer must not contain URLs or links",
+    "notUrl": "Answer must not contain a URL",
     "regex": "Enter a valid UAN. For example, 1111-2222-3333-4444",
     "isValidUANRef": "Enter a valid UAN. For example, 1111-2222-3333-4444"
   },

--- a/apps/report-documents-not-received/translations/src/en/validation.json
+++ b/apps/report-documents-not-received/translations/src/en/validation.json
@@ -58,6 +58,14 @@
     "maxlength": "Courier reference number cannot be more than 100 characters",
     "notUrl": "Answer must not contain a URL"
   },
+  "dnr-unique-application-number": {
+    "required": "Enter a unique application number",
+    "minlength": "Unique application number must be more than 15 numbers",
+    "maxlength": "Unique application number must be less than 23 numbers",
+    "notUrl": "Your answer must not contain URLs or links",
+    "regex": "Enter a valid UAN. For example, 1111-2222-3333-4444",
+    "isValidUANRef": "Enter a valid UAN. For example, 1111-2222-3333-4444"
+  },
   "dnr-email": {
     "required": "Enter a contact email address",
     "minlength": "Email address must be between 6 and 256 characters",

--- a/apps/rod/behaviours/send-email-notification.js
+++ b/apps/rod/behaviours/send-email-notification.js
@@ -107,6 +107,14 @@ const getUserDetails = req => {
       req,
       'rod-courier-reference-number'
     ),
+    has_unique_application_number: getYesOrNoStr(
+      req,
+      'rod-unique-application-number'
+    ),
+    unique_application_number: getValueOfDefault(
+      req,
+      'rod-unique-application-number'
+    ),
     has_your_documents: getYesOrNoStr(req, 'yourDocuments'),
     your_documents: getValueOfDefault(req, 'yourDocuments'),
     has_document_description: getYesOrNoStr(req, 'document-description'),

--- a/apps/rod/fields/index.js
+++ b/apps/rod/fields/index.js
@@ -336,11 +336,11 @@ module.exports = {
     className: ['govuk-input'],
     validate: [
       'required',
+      'notUrl',
       { type: 'minlength', arguments: 16 },
       { type: 'maxlength', arguments: 22 },
       { type: 'regex', arguments: /^(([\d\-\/]+)?)$/ },
-      isValidUANRef,
-      'notUrl'
+      isValidUANRef
     ]
   }
 };

--- a/apps/rod/fields/index.js
+++ b/apps/rod/fields/index.js
@@ -1,7 +1,10 @@
 const dateComponent = require('hof').components.date;
 const countries = require('hof').utils.countries();
 const validators = require('hof/controller/validation/validators');
-const { validInternationalPhoneNumber } = require('../../../utils');
+const {
+  validInternationalPhoneNumber,
+  isValidUANRef
+} = require('../../../utils');
 
 function extraNotes(value) {
   return validators.maxlength(value, 2000);
@@ -274,6 +277,11 @@ module.exports = {
         value: 'courier-reference-number',
         toggle: 'rod-courier-reference-number',
         child: 'input-text'
+      },
+      {
+        value: 'unique-application-number',
+        toggle: 'rod-unique-application-number',
+        child: 'input-text'
       }
     ]
   },
@@ -319,5 +327,20 @@ module.exports = {
     },
     className: ['govuk-input'],
     validate: ['required', { type: 'maxlength', arguments: 100 }, 'notUrl']
+  },
+  'rod-unique-application-number': {
+    dependent: {
+      field: 'rod-reference-number',
+      value: 'unique-application-number'
+    },
+    className: ['govuk-input'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 16 },
+      { type: 'maxlength', arguments: 22 },
+      { type: 'regex', arguments: /^(([\d\-\/]+)?)$/ },
+      isValidUANRef,
+      'notUrl'
+    ]
   }
 };

--- a/apps/rod/index.js
+++ b/apps/rod/index.js
@@ -206,7 +206,8 @@ module.exports = {
         'rod-case-id',
         'rod-ho-reference-number',
         'rod-payment-reference-number',
-        'rod-courier-reference-number'
+        'rod-courier-reference-number',
+        'rod-unique-application-number'
       ],
       next: '/your-documents'
     },

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -90,6 +90,10 @@ module.exports = {
       field: 'rod-courier-reference-number'
     },
     {
+      step: '/reference-number',
+      field: 'rod-unique-application-number'
+    },
+    {
       field: 'document-type',
       parse: (value, req) => {
         const yourDocuments = Array.isArray(value) ?

--- a/apps/rod/translations/src/en/fields.json
+++ b/apps/rod/translations/src/en/fields.json
@@ -274,6 +274,10 @@
       "courier-reference-number": {
         "label": "Courier reference number",
         "hint": "This includes Royal Mail reference numbers"
+      },
+      "unique-application-number": {
+        "label": "Unique Application Number (UAN)",
+        "hint": "This is on letters and emails from the Home Office"
       }
     }
   },
@@ -289,6 +293,10 @@
   "rod-courier-reference-number": {
     "label": "Enter the courier reference number",
     "hint": "Royal Mail reference numbers are between 9 and 27 characters long"
+  },
+  "rod-unique-application-number": {
+    "label": "Enter the UAN",
+    "hint": "For example, 1111-2222-3333-4444"
   },
   "declaration-check": {
     "label": "I understand and agree to this declaration"

--- a/apps/rod/translations/src/en/pages.json
+++ b/apps/rod/translations/src/en/pages.json
@@ -148,6 +148,9 @@
       },
       "rod-courier-reference-number": {
         "label": "Courier reference number"
+      },
+      "rod-unique-application-number": {
+        "label": "Unique application number"
       }
     }
   },

--- a/apps/rod/translations/src/en/validation.json
+++ b/apps/rod/translations/src/en/validation.json
@@ -153,5 +153,13 @@
     "required": "Enter a courier reference number",
     "maxlength": "Courier reference number cannot be more than 100 characters",
     "notUrl": "Answer must not contain a URL"
+  },
+  "rod-unique-application-number": {
+    "required": "Enter a unique application number",
+    "minlength": "Unique application number must be more than 15 numbers",
+    "maxlength": "Unique application number must be less than 23 numbers",
+    "notUrl": "Your answer must not contain URLs or links",
+    "regex": "Enter a valid UAN. For example, 1111-2222-3333-4444",
+    "isValidUANRef": "Enter a valid UAN. For example, 1111-2222-3333-4444"
   }
 }

--- a/apps/rod/translations/src/en/validation.json
+++ b/apps/rod/translations/src/en/validation.json
@@ -158,7 +158,7 @@
     "required": "Enter a unique application number",
     "minlength": "Unique application number must be more than 15 numbers",
     "maxlength": "Unique application number must be less than 23 numbers",
-    "notUrl": "Your answer must not contain URLs or links",
+    "notUrl": "Answer must not contain a URL",
     "regex": "Enter a valid UAN. For example, 1111-2222-3333-4444",
     "isValidUANRef": "Enter a valid UAN. For example, 1111-2222-3333-4444"
   }

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -261,6 +261,16 @@ pre.looped-records {
   animation: spin 1s linear infinite;
 }
 
+@-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
 #is-passport-return-address-group.govuk-radios {
   margin-top: 20px;
 }

--- a/test/_unit/utils/utils.spec.js
+++ b/test/_unit/utils/utils.spec.js
@@ -80,4 +80,17 @@ describe('ROD utils tests', () => {
     req.sessionModel.set('ut_value', 'test_value');
     expect(utils.getYesOrNoStr(req, 'ut_value')).to.equal('yes');
   });
+
+  it('.isValidUANRef - should return null for invalid UAN formats', () => {
+    expect(utils.isValidUANRef('XXX123456789')).to.equal(null);
+    expect(utils.isValidUANRef('1234567890')).to.equal(null);
+    expect(utils.isValidUANRef('2222333344445555666677778888')).to.equal(null);
+    expect(utils.isValidUANRef('1111 2222 3333 4444')).to.equal(null);
+  });
+
+  it('.isValidUANRef - should return true for valid UAN formats', () => {
+    expect(utils.isValidUANRef('1111-2222-3333-4444')).to.not.equal(null);
+    expect(utils.isValidUANRef('1111222233334444')).to.not.equal(null);
+    expect(utils.isValidUANRef('1234-1234-1234-1234/00')).to.not.equal(null);
+  });
 });

--- a/utils/index.js
+++ b/utils/index.js
@@ -38,11 +38,18 @@ const getYesOrNoStr = (req, field) => {
   return req.sessionModel.get(field) ? 'yes' : 'no';
 };
 
+const isValidUANRef = value => {
+  return value.match(
+    /^((\d{4}[\-]?\d{4}[\-]?\d{4}[\-]?\d{4}(?:[\/]?\d{2})?)?)$/
+  );
+};
+
 module.exports = {
   removeWhiteSpace,
   validInternationalPhoneNumber,
   getFormattedRecordNumber,
   getLabel,
   getValueOfDefault,
-  getYesOrNoStr
+  getYesOrNoStr,
+  isValidUANRef
 };


### PR DESCRIPTION
## What? 
[ROD-151](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-151) - Add UAN in reference numbers

Associated tickets
> https://collaboration.homeoffice.gov.uk/jira/browse/ROD-151
> https://collaboration.homeoffice.gov.uk/jira/browse/ROD-152
> https://collaboration.homeoffice.gov.uk/jira/browse/ROD-153
## Why? 
UAN needs to be added in the list of reference numbers for all 3 ROD forms
## How? 
New UAN field has been added to all 3 forms
## Testing?
Local and branch testing
## Screenshots (optional)

**ROD Main flow**

![Screenshot 2024-12-03 at 11 29 29](https://github.com/user-attachments/assets/69a7d0fb-b349-4ce7-bba6-99ba37139b5e)

**Cancel Request**

![Screenshot 2024-12-03 at 11 30 50](https://github.com/user-attachments/assets/e07893fc-677a-4c9a-8c7d-c78710ff3f59)

**Documents not received**

![Screenshot 2024-12-03 at 11 31 38](https://github.com/user-attachments/assets/fab2c291-5848-4022-b8d9-bad96e20eca2)


## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
