### PR TITLE
ROD-150 Show optional fields in summary page

### DIFF
--- a/apps/rod/behaviours/send-email-notification.js
+++ b/apps/rod/behaviours/send-email-notification.js
@@ -117,8 +117,8 @@ const getUserDetails = req => {
     ),
     has_your_documents: 'yes',
     your_documents: getValueOfDefault(req, 'yourDocuments') || 'Not provided',
-    has_document_description: getYesOrNoStr(req, 'document-description'),
-    document_description: getValueOfDefault(req, 'document-description'),
+    has_document_description: 'yes',
+    document_description: getValueOfDefault(req, 'document-description') || 'Not provided',
     applicant_full_name: getValueOfDefault(req, 'main-applicant-full-name'),
     applicant_dob: dateFormatter.format(
       new Date(getValueOfDefault(req, 'main-applicant-dob'))

--- a/apps/rod/behaviours/send-email-notification.js
+++ b/apps/rod/behaviours/send-email-notification.js
@@ -115,8 +115,8 @@ const getUserDetails = req => {
       req,
       'rod-unique-application-number'
     ),
-    has_your_documents: getYesOrNoStr(req, 'yourDocuments'),
-    your_documents: getValueOfDefault(req, 'yourDocuments'),
+    has_your_documents: 'yes',
+    your_documents: getValueOfDefault(req, 'yourDocuments') || 'Not provided',
     has_document_description: getYesOrNoStr(req, 'document-description'),
     document_description: getValueOfDefault(req, 'document-description'),
     applicant_full_name: getValueOfDefault(req, 'main-applicant-full-name'),
@@ -128,8 +128,8 @@ const getUserDetails = req => {
     delivery_address: getValueOfDefault(req, 'deliveryAddress'),
     contact_email: getValueOfDefault(req, 'contact-email'),
     contact_telephone: getValueOfDefault(req, 'contact-telephone'),
-    has_notes: getYesOrNoStr(req, 'notes'),
-    notes: getValueOfDefault(req, 'notes')
+    has_notes: 'yes',
+    notes: getValueOfDefault(req, 'notes') || 'Not provided'
   };
 };
 

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -101,11 +101,11 @@ module.exports = {
           return 'Not provided';
         }
         const yourDocuments = Array.isArray(value)
-          ? value.map(option => 
-              option === 'Other' 
-                ? req.sessionModel.get('enter-document-type') || 'Other (not specified)'
-                : option
-            ).join(', ')
+          ? value.map(option =>
+            option === 'Other'
+              ? req.sessionModel.get('enter-document-type') || 'Other (not specified)'
+              : option
+          ).join(', ')
           : value;
         req.sessionModel.set('yourDocuments', yourDocuments);
         return yourDocuments;

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -96,17 +96,16 @@ module.exports = {
     {
       field: 'document-type',
       parse: (value, req) => {
-        if (!value || (Array.isArray(value) && value.length === 0)) {
-          req.sessionModel.set('yourDocuments', 'Not provided');
-          return 'Not provided';
-        }
-        const yourDocuments = Array.isArray(value)
+        let yourDocuments = Array.isArray(value)
           ? value.map(option =>
             option === 'Other'
               ? req.sessionModel.get('enter-document-type') || 'Other (not specified)'
               : option
           ).join(', ')
           : value;
+        if (!yourDocuments) {
+          yourDocuments = 'Not provided';
+        }
         req.sessionModel.set('yourDocuments', yourDocuments);
         return yourDocuments;
       }

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -99,7 +99,7 @@ module.exports = {
         let yourDocuments = Array.isArray(value)
           ? value.map(option =>
             option === 'Other'
-              ? req.sessionModel.get('enter-document-type') || 'Other (not specified)'
+              ? req.sessionModel.get('enter-document-type')
               : option
           ).join(', ')
           : value;

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -105,7 +105,10 @@ module.exports = {
     },
     {
       step: '/your-documents',
-      field: 'document-description'
+      field: 'document-description',
+      parse: value => {
+        return value && value.trim() ? value : 'Not provided';
+      }
     },
     {
       step: '/main-applicant',
@@ -182,7 +185,10 @@ module.exports = {
     },
     {
       step: '/extra-notes',
-      field: 'notes'
+      field: 'notes',
+      parse: value => {
+        return value && value.trim() ? value : 'Not provided';
+      }
     }
   ]
 };

--- a/apps/rod/sections/summary-data-sections.js
+++ b/apps/rod/sections/summary-data-sections.js
@@ -96,9 +96,17 @@ module.exports = {
     {
       field: 'document-type',
       parse: (value, req) => {
-        const yourDocuments = Array.isArray(value) ?
-          value.map(option => option === 'Other' ? req.sessionModel.get('enter-document-type') : option).join(', ') :
-          value;
+        if (!value || (Array.isArray(value) && value.length === 0)) {
+          req.sessionModel.set('yourDocuments', 'Not provided');
+          return 'Not provided';
+        }
+        const yourDocuments = Array.isArray(value)
+          ? value.map(option => 
+              option === 'Other' 
+                ? req.sessionModel.get('enter-document-type') || 'Other (not specified)'
+                : option
+            ).join(', ')
+          : value;
         req.sessionModel.set('yourDocuments', yourDocuments);
         return yourDocuments;
       }


### PR DESCRIPTION
## What? 
[ROD-150](https://collaboration.homeoffice.gov.uk/jira/browse/ROD-150) - Show optional fields in the summary page screen for ROD main flow
## Why? 
Allows user to see optional fields and change if they want.

## How? 
-Added logic to show optional fields.

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging