### PR TITLE
ROD-179: Add exit routes

### DIFF
--- a/apps/cancel-request/index.js
+++ b/apps/cancel-request/index.js
@@ -111,6 +111,8 @@ module.exports = {
     '/cancellation-received': {
       clearSession: true,
       backLink: false
-    }
+    },
+    '/exit': {},
+    '/session-timeout': {}
   }
 };

--- a/apps/rod/index.js
+++ b/apps/rod/index.js
@@ -224,6 +224,8 @@ module.exports = {
     '/request-received': {
       clearSession: true,
       backLink: false
-    }
+    },
+    '/exit': {},
+    '/session-timeout': {}
   }
 };


### PR DESCRIPTION
## What?
Adding exit routes to the cancel-request and rod journey
## Why?
So that the exit pages for these journeys exist, currently they do not exist so a not found page will be displayed 
## How? 
* Add /exit routes to apps/rod/index.js and apps/cancel-request/index.js
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
